### PR TITLE
kv-framework-52: Rename Transaction and txCommit()

### DIFF
--- a/src/main/java/org/boudnik/framework/CacheProvider.java
+++ b/src/main/java/org/boudnik/framework/CacheProvider.java
@@ -7,13 +7,13 @@ public enum CacheProvider {
     IGNITE(IgniteTransaction.class),
     HAZELCAST(HazelcastTransaction.class);
 
-    private final Class<? extends Transaction> transactionClass;
+    private final Class<? extends Context> transactionClass;
 
-    <T extends Transaction> CacheProvider(Class<T> transactionClass) {
+    <T extends Context> CacheProvider(Class<T> transactionClass) {
         this.transactionClass = transactionClass;
     }
 
-    public Class<? extends Transaction> getTransactionClass() {
+    public Class<? extends Context> getTransactionClass() {
         return transactionClass;
     }
 }

--- a/src/main/java/org/boudnik/framework/Context.java
+++ b/src/main/java/org/boudnik/framework/Context.java
@@ -11,7 +11,7 @@ import java.util.Map;
  * @author Alexandre_Boudnik
  * @since 11/15/2017
  */
-public abstract class Transaction implements AutoCloseable {
+public abstract class Context implements AutoCloseable {
     private final Map<Class<? extends OBJ>, Map<Object, OBJ>> scope = new HashMap<>();
 
     public abstract <K, V extends OBJ> V get(Class<V> clazz, K identity);
@@ -111,8 +111,8 @@ public abstract class Transaction implements AutoCloseable {
 */
     }
 
-    public Transaction txCommit(OBJ obj) {
-        return txCommit(obj::save);
+    public Context transaction(OBJ obj) {
+        return transaction(obj::save);
     }
 
     @NotNull
@@ -134,7 +134,7 @@ public abstract class Transaction implements AutoCloseable {
     }
 
     @SuppressWarnings("unchecked")
-    public <T extends Transaction> T txCommit(Transactionable transactionable) {
+    public <T extends Context> T transaction(Transactionable transactionable) {
         startTransactionIfNotStarted();
         try {
             transactionable.commit();
@@ -150,7 +150,7 @@ public abstract class Transaction implements AutoCloseable {
         return OBJ.TOMBSTONE == reference;
     }
 
-    public static <T extends Transaction> T instance() {
+    public static <T extends Context> T instance() {
         return TransactionFactory.getCurrentTransaction();
     }
 

--- a/src/main/java/org/boudnik/framework/OBJ.java
+++ b/src/main/java/org/boudnik/framework/OBJ.java
@@ -21,16 +21,16 @@ public interface OBJ<K> extends Serializable {
 
     @SuppressWarnings("unchecked")
     default <T> T save() {
-        return (T) Transaction.instance().save(this);
+        return (T) Context.instance().save(this);
     }
 
     @SuppressWarnings("unchecked")
     default <T> T save(K key) {
-        return (T) Transaction.instance().save(this, key);
+        return (T) Context.instance().save(this, key);
     }
 
     default void delete() {
-        Transaction.instance().delete(this);
+        Context.instance().delete(this);
     }
 
     //  default void revert() {
@@ -121,12 +121,12 @@ public interface OBJ<K> extends Serializable {
          */
         public V get() {
             if (reference == null)
-                return identity == null ? null : (reference = Transaction.instance().get(clazz, identity));
-            V inScope = Transaction.instance().get(clazz, reference.getKey());
-            if (Transaction.isDeleted(inScope))
+                return identity == null ? null : (reference = Context.instance().get(clazz, identity));
+            V inScope = Context.instance().get(clazz, reference.getKey());
+            if (Context.isDeleted(inScope))
                 return null;
             if (inScope != reference)
-                return reference = Transaction.instance().get(clazz, identity);
+                return reference = Context.instance().get(clazz, identity);
             return reference;
         }
 

--- a/src/main/java/org/boudnik/framework/TransactionFactory.java
+++ b/src/main/java/org/boudnik/framework/TransactionFactory.java
@@ -3,36 +3,36 @@ package org.boudnik.framework;
 import java.util.function.Supplier;
 
 public class TransactionFactory {
-    private static final ThreadLocal<Transaction> TRANSACTION_THREAD_LOCAL = new ThreadLocal<>();
+    private static final ThreadLocal<Context> TRANSACTION_THREAD_LOCAL = new ThreadLocal<>();
 
     private TransactionFactory() {
     }
 
     @SuppressWarnings("unchecked")
-    static <T extends Transaction> T getCurrentTransaction() {
+    static <T extends Context> T getCurrentTransaction() {
         return (T) TRANSACTION_THREAD_LOCAL.get();
     }
 
-    public static <T extends Transaction> T getOrCreateTransaction(CacheProvider cacheProvider, Supplier<T> supplier) {
+    public static <T extends Context> T getOrCreateTransaction(CacheProvider cacheProvider, Supplier<T> supplier) {
         return getOrCreateTransaction(cacheProvider, supplier, false);
     }
 
     @SuppressWarnings("unchecked")
-    public static <T extends Transaction> T getOrCreateTransaction(CacheProvider cacheProvider, Supplier<T> supplier, boolean abortCurrentIfAnotherProviderPresent) {
+    public static <T extends Context> T getOrCreateTransaction(CacheProvider cacheProvider, Supplier<T> supplier, boolean abortCurrentIfAnotherProviderPresent) {
         if (supplier == null)
             throw new NullPointerException();
-        Transaction transaction = TRANSACTION_THREAD_LOCAL.get();
-        if (transaction != null) {
-            if (transaction.getClass().isAssignableFrom(cacheProvider.getTransactionClass())) return (T) transaction;
+        Context context = TRANSACTION_THREAD_LOCAL.get();
+        if (context != null) {
+            if (context.getClass().isAssignableFrom(cacheProvider.getTransactionClass())) return (T) context;
             else if (!abortCurrentIfAnotherProviderPresent) {
-                throw new RuntimeException("Another provider transaction is present " + transaction);
+                throw new RuntimeException("Another provider transaction is present " + context);
             } else {
                 TRANSACTION_THREAD_LOCAL.get().close();
             }
         }
 
-        transaction = supplier.get();
-        TRANSACTION_THREAD_LOCAL.set(transaction);
-        return (T) transaction;
+        context = supplier.get();
+        TRANSACTION_THREAD_LOCAL.set(context);
+        return (T) context;
     }
 }

--- a/src/main/java/org/boudnik/framework/hazelcast/HazelcastTransaction.java
+++ b/src/main/java/org/boudnik/framework/hazelcast/HazelcastTransaction.java
@@ -5,7 +5,7 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.transaction.TransactionContext;
 import org.boudnik.framework.OBJ;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
@@ -13,7 +13,7 @@ import javax.cache.spi.CachingProvider;
 import java.util.HashMap;
 import java.util.Map;
 
-public class HazelcastTransaction extends Transaction {
+public class HazelcastTransaction extends Context {
 
     private TransactionContext hazelcastTransactionContext;
     private final Map<OBJ, Object> mementos = new HashMap<>();

--- a/src/main/java/org/boudnik/framework/ignite/IgniteTransaction.java
+++ b/src/main/java/org/boudnik/framework/ignite/IgniteTransaction.java
@@ -4,7 +4,7 @@ import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.binary.BinaryObject;
 import org.boudnik.framework.OBJ;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 
 import javax.cache.Cache;
 import java.util.HashMap;
@@ -14,7 +14,7 @@ import java.util.Map;
  * @author Alexandre_Boudnik
  * @since 11/15/2017
  */
-public class IgniteTransaction extends Transaction {
+public class IgniteTransaction extends Context {
 
     private final Map<OBJ, BinaryObject> mementos = new HashMap<>();
     private final Ignite ignite;

--- a/src/test/java/org/boudnik/framework/test/Main.java
+++ b/src/test/java/org/boudnik/framework/test/Main.java
@@ -3,7 +3,7 @@ package org.boudnik.framework.test;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.TransactionFactory;
 import org.boudnik.framework.ignite.IgniteTransaction;
 import org.boudnik.framework.test.core.TestEntry;
@@ -28,8 +28,8 @@ public class Main {
 
     @Test
     public void main() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(() -> new TestEntry("http://localhost/1").save(""));
+        Context tx = Context.instance();
+        tx.transaction(() -> new TestEntry("http://localhost/1").save(""));
     }
 
     @Test
@@ -38,8 +38,8 @@ public class Main {
         for (int i = 0; i < 2; i++) {
             executor.submit(() -> {
                 try {
-                    Transaction tx = TransactionFactory.getOrCreateTransaction(CacheProvider.IGNITE, () -> new IgniteTransaction(Ignition.getOrStart(new IgniteConfiguration())), true).withCache(TestEntry.class);
-                    tx.txCommit(() -> new TestEntry("http://localhost/1").save(""));
+                    Context tx = TransactionFactory.getOrCreateTransaction(CacheProvider.IGNITE, () -> new IgniteTransaction(Ignition.getOrStart(new IgniteConfiguration())), true).withCache(TestEntry.class);
+                    tx.transaction(() -> new TestEntry("http://localhost/1").save(""));
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -48,7 +48,7 @@ public class Main {
 
         try {
             executor.awaitTermination(2, TimeUnit.SECONDS);
-            Assert.assertNotNull(Transaction.instance().get(TestEntry.class, ""));
+            Assert.assertNotNull(Context.instance().get(TestEntry.class, ""));
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/test/java/org/boudnik/framework/test/ObjSaveTest.java
+++ b/src/test/java/org/boudnik/framework/test/ObjSaveTest.java
@@ -3,7 +3,7 @@ package org.boudnik.framework.test;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.TransactionFactory;
 import org.boudnik.framework.ignite.IgniteTransaction;
 import org.boudnik.framework.test.core.TestEntry;
@@ -20,8 +20,8 @@ public class ObjSaveTest {
 
     @Test
     public void checkSeveralEntriesWithDifferentKeys() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(() -> {
+        Context tx = Context.instance();
+        tx.transaction(() -> {
             new TestEntry("http://localhost/1").save("checkSeveralEntriesWithDifferentKeys");
             new TestEntry("http://localhost/1").save();
         });

--- a/src/test/java/org/boudnik/framework/test/testsuites/CreateDeleteTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/CreateDeleteTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.TestEntry;
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,8 +14,8 @@ public class CreateDeleteTest extends TransactionTest {
 
     @Test
     public void testCreateDeleteCommit() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(() -> {
+        Context tx = Context.instance();
+        tx.transaction(() -> {
             TestEntry te = new TestEntry("testCreateDeleteCommit");
             te.save();
             te.delete();
@@ -25,7 +25,7 @@ public class CreateDeleteTest extends TransactionTest {
 
     @Test
     public void testCreateDeleteRollback() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         TestEntry te = new TestEntry("testCreateDeleteRollback");
         TestEntry saveResult = te.save();
         Assert.assertNotNull(saveResult);
@@ -36,8 +36,8 @@ public class CreateDeleteTest extends TransactionTest {
 
     @Test(expected = RuntimeException.class)
     public void testCreateDeleteRollbackViaException() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(() -> {
+        Context tx = Context.instance();
+        tx.transaction(() -> {
             TestEntry te = new TestEntry("testCreateDeleteRollback");
             te.save();
             te.delete();

--- a/src/test/java/org/boudnik/framework/test/testsuites/CreateSaveDeleteTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/CreateSaveDeleteTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.TestEntry;
 import org.junit.Assert;
 import org.junit.Test;
@@ -16,20 +16,20 @@ public class CreateSaveDeleteTest extends TransactionTest {
 
     @Test
     public void testCommitDeleteCommit() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new TestEntry("testCommitDeleteCommit"));
+        Context tx = Context.instance();
+        tx.transaction(new TestEntry("testCommitDeleteCommit"));
 
         TestEntry entry = tx.get(TestEntry.class, "testCommitDeleteCommit");
         Assert.assertNotNull(entry);
 
-        tx.txCommit(entry::delete);
+        tx.transaction(entry::delete);
         Assert.assertNull(tx.getAndClose(TestEntry.class, "testCommitDeleteCommit"));
     }
 
     @Test
     public void testCommitDeleteRollback() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new TestEntry("testCommitDeleteRollback"));
+        Context tx = Context.instance();
+        tx.transaction(new TestEntry("testCommitDeleteRollback"));
 
         TestEntry entry = tx.get(TestEntry.class, "testCommitDeleteRollback");
         Assert.assertNotNull(entry);
@@ -41,13 +41,13 @@ public class CreateSaveDeleteTest extends TransactionTest {
 
     @Test(expected = RuntimeException.class)
     public void testCommitDeleteRollbackViaException() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new TestEntry("testCommitDeleteRollback"));
+        Context tx = Context.instance();
+        tx.transaction(new TestEntry("testCommitDeleteRollback"));
 
         TestEntry entry = tx.get(TestEntry.class, "testCommitDeleteRollback");
         Assert.assertNotNull(entry);
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.delete();
             throw new RuntimeException("RollbackException");
         });

--- a/src/test/java/org/boudnik/framework/test/testsuites/CreateSaveRefTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/CreateSaveRefTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.RefTestEntry;
 import org.boudnik.framework.test.core.TestEntry;
 import org.junit.Test;
@@ -18,15 +18,15 @@ public class CreateSaveRefTest extends TransactionTest {
 
     @Test
     public void testCreateSaveCommit() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(() -> {
+        Context tx = Context.instance();
+        tx.transaction(() -> {
             TestEntry entry = new TestEntry("test").save();
             ref = new RefTestEntry("test", entry).save();
             assertSame(tx.get(TestEntry.class, "test"), entry);
             assertSame(ref.getEntry(), entry);
         });
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             TestEntry actual = tx.get(TestEntry.class, "test");
             TestEntry expected = ref.getEntry();
             assertSame(actual, expected);

--- a/src/test/java/org/boudnik/framework/test/testsuites/CreateSaveTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/CreateSaveTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.TestEntry;
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,14 +14,14 @@ public class CreateSaveTest extends TransactionTest {
 
     @Test
     public void testCreateSaveCommit() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new TestEntry("testCreateSaveCommit"));
+        Context tx = Context.instance();
+        tx.transaction(new TestEntry("testCreateSaveCommit"));
         Assert.assertNotNull(tx.getAndClose(TestEntry.class, "testCreateSaveCommit"));
     }
 
     @Test
     public void testCreateSaveRollback() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         TestEntry saveResult = new TestEntry("testCreateSaveRollback").save();
         Assert.assertNotNull(saveResult);
         tx.rollback();
@@ -30,8 +30,8 @@ public class CreateSaveTest extends TransactionTest {
 
     @Test(expected = RuntimeException.class)
     public void testCreateSaveRollbackViaException() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(() -> {
+        Context tx = Context.instance();
+        tx.transaction(() -> {
             new TestEntry("testCreateSaveRollback").save();
             throw new RuntimeException("Rollback Exception");
         });

--- a/src/test/java/org/boudnik/framework/test/testsuites/GetDeleteComplexEntryTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/GetDeleteComplexEntryTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.ComplexTestEntry;
 import org.boudnik.framework.test.core.ComplexTestEntry2;
 import org.boudnik.framework.test.core.TestEntry;
@@ -19,22 +19,22 @@ public class GetDeleteComplexEntryTest extends TransactionTest {
 
     @Test
     public void testGetDeleteCommitComplexTestEntry2() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         ComplexTestEntry2 te = new ComplexTestEntry2(new ComplexTestEntry(new TestEntry("testGetDeleteCommitComplex")));
-        tx.txCommit(te);
+        tx.transaction(te);
 
         ComplexTestEntry key = te.getKey();
         ComplexTestEntry2 entry = tx.get(ComplexTestEntry2.class, key);
         Assert.assertNotNull(entry);
-        tx.txCommit(entry::delete);
+        tx.transaction(entry::delete);
         Assert.assertNull(tx.getAndClose(ComplexTestEntry2.class, key));
     }
 
     @Test
     public void testGetDeleteRollbackComplexTestEntry2() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         ComplexTestEntry2 te = new ComplexTestEntry2(new ComplexTestEntry(new TestEntry("testCommitDeleteRollback")));
-        tx.txCommit(te);
+        tx.transaction(te);
 
         ComplexTestEntry key = te.getKey();
         ComplexTestEntry2 entry = tx.get(ComplexTestEntry2.class, key);
@@ -47,15 +47,15 @@ public class GetDeleteComplexEntryTest extends TransactionTest {
 
     @Test(expected = RuntimeException.class)
     public void testGetDeleteRollbackViaExceptionComplexTestEntry2() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         ComplexTestEntry2 te = new ComplexTestEntry2(new ComplexTestEntry(new TestEntry("testCommitDeleteRollback")));
-        tx.txCommit(te);
+        tx.transaction(te);
 
         ComplexTestEntry key = te.getKey();
         ComplexTestEntry2 entry = tx.get(ComplexTestEntry2.class, key);
         Assert.assertNotNull(entry);
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.delete();
             throw new RuntimeException("RollbackException");
         });

--- a/src/test/java/org/boudnik/framework/test/testsuites/GetDeleteTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/GetDeleteTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.MutableTestEntry;
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,20 +14,20 @@ public class GetDeleteTest extends TransactionTest {
 
     @Test
     public void testGetDeleteCommit() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new MutableTestEntry("testGetDeleteCommit"));
+        Context tx = Context.instance();
+        tx.transaction(new MutableTestEntry("testGetDeleteCommit"));
 
         MutableTestEntry entry = tx.get(MutableTestEntry.class, "testGetDeleteCommit");
         Assert.assertNotNull(entry);
 
-        tx.txCommit(entry::delete);
+        tx.transaction(entry::delete);
         Assert.assertNull(tx.get(MutableTestEntry.class, "testGetDeleteCommit"));
     }
 
     @Test
     public void testGetDeleteRollback() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new MutableTestEntry("testGetDeleteRollback"));
+        Context tx = Context.instance();
+        tx.transaction(new MutableTestEntry("testGetDeleteRollback"));
 
         MutableTestEntry entry = tx.get(MutableTestEntry.class, "testGetDeleteRollback");
         Assert.assertNotNull(entry);
@@ -39,12 +39,12 @@ public class GetDeleteTest extends TransactionTest {
 
     @Test(expected = RuntimeException.class)
     public void testGetDeleteRollbackViaException() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new MutableTestEntry("testGetDeleteRollback"));
+        Context tx = Context.instance();
+        tx.transaction(new MutableTestEntry("testGetDeleteRollback"));
 
         MutableTestEntry entry = tx.get(MutableTestEntry.class, "testGetDeleteRollback");
         Assert.assertNotNull(entry);
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.delete();
             throw new RuntimeException("Rollback Exception");
         });

--- a/src/test/java/org/boudnik/framework/test/testsuites/GetUpdateSaveComplexEntryTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/GetUpdateSaveComplexEntryTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.ComplexTestEntry;
 import org.boudnik.framework.test.core.ComplexTestEntry2;
 import org.boudnik.framework.test.core.TestEntry;
@@ -18,15 +18,15 @@ public class GetUpdateSaveComplexEntryTest extends TransactionTest {
 
     @Test
     public void testGetUpdateSaveCommitComplexTestEntry() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         ComplexTestEntry2 te = new ComplexTestEntry2(new ComplexTestEntry(new TestEntry("testUpdateCommit")));
-        tx.txCommit(te);
+        tx.transaction(te);
 
         ComplexTestEntry key = te.getKey();
         ComplexTestEntry2 entry = tx.get(ComplexTestEntry2.class, key);
         Assert.assertNotNull(entry);
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.setValue(NEW_VALUE);
             entry.getKey().setValue(NEW_VALUE);
             entry.save();
@@ -38,9 +38,9 @@ public class GetUpdateSaveComplexEntryTest extends TransactionTest {
 
     @Test
     public void testGetUpdateSaveRollbackComplexTestEntry() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         ComplexTestEntry2 te = new ComplexTestEntry2(new ComplexTestEntry(new TestEntry("testUpdateRollback")));
-        tx.txCommit(te);
+        tx.transaction(te);
 
         ComplexTestEntry key = te.getKey();
         ComplexTestEntry2 entry = tx.get(ComplexTestEntry2.class, key);
@@ -58,15 +58,15 @@ public class GetUpdateSaveComplexEntryTest extends TransactionTest {
 
     @Test(expected = RuntimeException.class)
     public void testGetUpdateSaveRollbackViaExceptionComplexTestEntry() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         ComplexTestEntry2 te = new ComplexTestEntry2(new ComplexTestEntry(new TestEntry("testUpdateRollback")));
-        tx.txCommit(te);
+        tx.transaction(te);
 
         ComplexTestEntry key = te.getKey();
         ComplexTestEntry2 entry = tx.get(ComplexTestEntry2.class, key);
         Assert.assertNotNull(entry);
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.setValue(NEW_VALUE);
             entry.getKey().setValue(NEW_VALUE);
             entry.save();

--- a/src/test/java/org/boudnik/framework/test/testsuites/GetUpdateSaveDeleteComplexEntryTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/GetUpdateSaveDeleteComplexEntryTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.ComplexTestEntry;
 import org.boudnik.framework.test.core.ComplexTestEntry2;
 import org.boudnik.framework.test.core.TestEntry;
@@ -21,9 +21,9 @@ public class GetUpdateSaveDeleteComplexEntryTest extends TransactionTest {
 
     @Test
     public void testGetUpdateSaveDeleteCommit() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         ComplexTestEntry2 te = new ComplexTestEntry2(new ComplexTestEntry(new TestEntry("testCommitDeleteCommit")));
-        tx.txCommit(te);
+        tx.transaction(te);
 
         ComplexTestEntry key = te.getKey();
         ComplexTestEntry2 entry = tx.get(ComplexTestEntry2.class, key);
@@ -31,7 +31,7 @@ public class GetUpdateSaveDeleteComplexEntryTest extends TransactionTest {
         Assert.assertNull(entry.getKey().getValue());
         Assert.assertNull(entry.getValue());
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.setValue(NEW_VALUE);
             entry.getKey().setValue(NEW_VALUE);
             entry.save();
@@ -44,9 +44,9 @@ public class GetUpdateSaveDeleteComplexEntryTest extends TransactionTest {
 
     @Test
     public void testGetUpdateSaveDeleteRollback() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         ComplexTestEntry2 te = new ComplexTestEntry2(new ComplexTestEntry(new TestEntry("testCommitDeleteRollback")));
-        tx.txCommit(te);
+        tx.transaction(te);
 
         ComplexTestEntry key = te.getKey();
         ComplexTestEntry2 entry = tx.get(ComplexTestEntry2.class, key);
@@ -67,15 +67,15 @@ public class GetUpdateSaveDeleteComplexEntryTest extends TransactionTest {
 
     @Test(expected = RuntimeException.class)
     public void testGetUpdateSaveDeleteRollbackViaException() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         ComplexTestEntry2 te = new ComplexTestEntry2(new ComplexTestEntry(new TestEntry("testCommitDeleteRollback")));
-        tx.txCommit(te);
+        tx.transaction(te);
 
         ComplexTestEntry key = te.getKey();
         ComplexTestEntry2 entry = tx.get(ComplexTestEntry2.class, key);
         Assert.assertNotNull(entry);
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.setValue(NEW_VALUE);
             entry.getKey().setValue(NEW_VALUE);
             entry.save();

--- a/src/test/java/org/boudnik/framework/test/testsuites/GetUpdateSaveDeleteTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/GetUpdateSaveDeleteTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.MutableTestEntry;
 import org.junit.Assert;
 import org.junit.Test;
@@ -16,14 +16,14 @@ public class GetUpdateSaveDeleteTest extends TransactionTest {
 
     @Test
     public void testGetUpdateSaveDeleteCommit() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new MutableTestEntry("testGetUpdateSaveDeleteCommit"));
+        Context tx = Context.instance();
+        tx.transaction(new MutableTestEntry("testGetUpdateSaveDeleteCommit"));
 
         final MutableTestEntry entry = tx.get(MutableTestEntry.class, "testGetUpdateSaveDeleteCommit");
         Assert.assertNotNull(entry);
         Assert.assertNull(entry.getValue());
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.setValue(NEW_VALUE);
             entry.save();
             entry.delete();
@@ -33,8 +33,8 @@ public class GetUpdateSaveDeleteTest extends TransactionTest {
 
     @Test
     public void testGetUpdateSaveDeleteRollback() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new MutableTestEntry("testGetUpdateSaveDeleteRollback"));
+        Context tx = Context.instance();
+        tx.transaction(new MutableTestEntry("testGetUpdateSaveDeleteRollback"));
 
         MutableTestEntry entry = tx.get(MutableTestEntry.class, "testGetUpdateSaveDeleteRollback");
         Assert.assertNotNull(entry);
@@ -52,14 +52,14 @@ public class GetUpdateSaveDeleteTest extends TransactionTest {
 
     @Test(expected = RuntimeException.class)
     public void testGetUpdateSaveDeleteRollbackViaException() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new MutableTestEntry("testGetUpdateSaveDeleteRollback"));
+        Context tx = Context.instance();
+        tx.transaction(new MutableTestEntry("testGetUpdateSaveDeleteRollback"));
 
         final MutableTestEntry entry = tx.get(MutableTestEntry.class, "testGetUpdateSaveDeleteRollback");
         Assert.assertNotNull(entry);
         Assert.assertNull(entry.getValue());
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.setValue(NEW_VALUE);
             entry.save();
             entry.delete();

--- a/src/test/java/org/boudnik/framework/test/testsuites/GetUpdateSaveTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/GetUpdateSaveTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.MutableTestEntry;
 import org.junit.Assert;
 import org.junit.Test;
@@ -16,14 +16,14 @@ public class GetUpdateSaveTest extends TransactionTest {
 
     @Test
     public void testGetUpdateSaveCommit() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new MutableTestEntry("testGetUpdateSaveCommit"));
+        Context tx = Context.instance();
+        tx.transaction(new MutableTestEntry("testGetUpdateSaveCommit"));
 
         final MutableTestEntry entry = tx.get(MutableTestEntry.class, "testGetUpdateSaveCommit");
         Assert.assertNotNull(entry);
         Assert.assertNull(entry.getValue());
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.setValue(NEW_VALUE);
             entry.save();
         });
@@ -32,8 +32,8 @@ public class GetUpdateSaveTest extends TransactionTest {
 
     @Test
     public void testGetUpdateSaveRollback() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new MutableTestEntry("testGetUpdateSaveRollback"));
+        Context tx = Context.instance();
+        tx.transaction(new MutableTestEntry("testGetUpdateSaveRollback"));
 
         final MutableTestEntry entry = tx.get(MutableTestEntry.class, "testGetUpdateSaveRollback");
         Assert.assertNotNull(entry);
@@ -48,14 +48,14 @@ public class GetUpdateSaveTest extends TransactionTest {
 
     @Test(expected = RuntimeException.class)
     public void testGetUpdateSaveRollbackViaException() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(new MutableTestEntry("testGetUpdateSaveRollback"));
+        Context tx = Context.instance();
+        tx.transaction(new MutableTestEntry("testGetUpdateSaveRollback"));
 
         final MutableTestEntry entry = tx.get(MutableTestEntry.class, "testGetUpdateSaveRollback");
         Assert.assertNotNull(entry);
         Assert.assertNull(entry.getValue());
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.setValue(NEW_VALUE);
             entry.save();
             throw new RuntimeException("Rollback Exception");

--- a/src/test/java/org/boudnik/framework/test/testsuites/MultipleClassesWithSameKeyTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/MultipleClassesWithSameKeyTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.ComplexTestEntry;
 import org.boudnik.framework.test.core.ComplexTestEntry2;
 import org.boudnik.framework.test.core.TestEntry;
@@ -15,30 +15,30 @@ public class MultipleClassesWithSameKeyTest extends TransactionTest {
 
     @Test
     public void MultipleEntriesWithSameKey() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         ComplexTestEntry2 te = new ComplexTestEntry2(new ComplexTestEntry(new TestEntry("Some key")));
-        tx.txCommit(te);
-        tx.txCommit(new TestEntry("Some key"));
+        tx.transaction(te);
+        tx.transaction(new TestEntry("Some key"));
 
         ComplexTestEntry key = te.getKey();
         ComplexTestEntry2 entry = tx.get(ComplexTestEntry2.class, key);
         Assert.assertNotNull(entry);
-        tx.txCommit(entry::delete);
+        tx.transaction(entry::delete);
         Assert.assertNull(tx.getAndClose(ComplexTestEntry2.class, key));
         Assert.assertNotNull(tx.getAndClose(TestEntry.class, "Some key"));
     }
 
     @Test
     public void MultipleEntriesWithSameKey2() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         ComplexTestEntry2 te = new ComplexTestEntry2(new ComplexTestEntry(new TestEntry("Other key")));
-        tx.txCommit(te);
-        tx.txCommit(new TestEntry("Other key"));
+        tx.transaction(te);
+        tx.transaction(new TestEntry("Other key"));
 
         ComplexTestEntry key = te.getKey();
         TestEntry entry = tx.get(TestEntry.class, "Other key");
         Assert.assertNotNull(entry);
-        tx.txCommit(entry::delete);
+        tx.transaction(entry::delete);
         Assert.assertNull(tx.getAndClose(TestEntry.class, "Other key"));
         Assert.assertNotNull(tx.getAndClose(ComplexTestEntry2.class, key));
     }

--- a/src/test/java/org/boudnik/framework/test/testsuites/SaveDeleteComplexRefTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/SaveDeleteComplexRefTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.ComplexRefTestEntry;
 import org.boudnik.framework.test.core.RefTestEntry;
 import org.boudnik.framework.test.core.TestEntry;
@@ -20,19 +20,19 @@ public class SaveDeleteComplexRefTest extends TransactionTest {
 
     @Test
     public void testSaveDeleteOBJCommit() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(() -> {
+        Context tx = Context.instance();
+        tx.transaction(() -> {
             TestEntry entry = new TestEntry("CreateSaveDeleteOBJCommit").save();
             ref = new RefTestEntry("CreateSaveDeleteOBJCommit", entry).save();
             complexRef = new ComplexRefTestEntry("CreateSaveDeleteOBJCommit", ref).save();
         });
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             TestEntry actual = tx.get(TestEntry.class, "CreateSaveDeleteOBJCommit");
             actual.delete();
         });
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             assertNull(tx.get(TestEntry.class, "CreateSaveDeleteOBJCommit"));
             RefTestEntry actualRef = tx.get(RefTestEntry.class, ref.getKey());
             ComplexRefTestEntry actualComplexRef = tx.get(ComplexRefTestEntry.class, complexRef.getKey());
@@ -44,19 +44,19 @@ public class SaveDeleteComplexRefTest extends TransactionTest {
 
     @Test
     public void testSaveDeleteRefCommit() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(() -> {
+        Context tx = Context.instance();
+        tx.transaction(() -> {
             TestEntry entry = new TestEntry("CreateSaveDeleteREFCommit").save();
             ref = new RefTestEntry("CreateSaveDeleteREFCommit", entry).save();
             complexRef = new ComplexRefTestEntry("CreateSaveDeleteREFCommit", ref).save();
         });
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             RefTestEntry actualRef = tx.get(RefTestEntry.class, ref.getKey());
             actualRef.delete();
         });
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             assertNull(tx.get(RefTestEntry.class, ref.getKey()));
             TestEntry actual = tx.get(TestEntry.class, "CreateSaveDeleteREFCommit");
             assertSame(actual, ref.getEntry());
@@ -67,8 +67,8 @@ public class SaveDeleteComplexRefTest extends TransactionTest {
 
     @Test
     public void testSaveDeleteOBJRollback() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(() -> {
+        Context tx = Context.instance();
+        tx.transaction(() -> {
             TestEntry entry = new TestEntry("CreateSaveDeleteOBJRollback").save();
             ref = new RefTestEntry("CreateSaveDeleteOBJRollback", entry).save();
             complexRef = new ComplexRefTestEntry("CreateSaveDeleteOBJRollback", ref).save();
@@ -78,7 +78,7 @@ public class SaveDeleteComplexRefTest extends TransactionTest {
         entryToBeDeleted.delete();
         tx.rollback();
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             TestEntry actualEntry = tx.get(TestEntry.class, "CreateSaveDeleteOBJRollback");
             assertNotNull(actualEntry);
             RefTestEntry actualRef = tx.get(RefTestEntry.class, ref.getKey());
@@ -91,8 +91,8 @@ public class SaveDeleteComplexRefTest extends TransactionTest {
 
     @Test
     public void testSaveDeleteRefRollback() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(() -> {
+        Context tx = Context.instance();
+        tx.transaction(() -> {
             TestEntry entry = new TestEntry("CreateSaveDeleteREFRollback").save();
             ref = new RefTestEntry("CreateSaveDeleteREFRollback", entry).save();
             complexRef = new ComplexRefTestEntry("CreateSaveDeleteREFRollback", ref).save();
@@ -102,7 +102,7 @@ public class SaveDeleteComplexRefTest extends TransactionTest {
         refToBeDeleted.delete();
         tx.rollback();
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             RefTestEntry actualRef = tx.get(RefTestEntry.class, ref.getKey());
             assertNotNull(actualRef);
             TestEntry actual = tx.get(TestEntry.class, "CreateSaveDeleteREFRollback");

--- a/src/test/java/org/boudnik/framework/test/testsuites/SaveDeleteRefTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/SaveDeleteRefTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.RefTestEntry;
 import org.boudnik.framework.test.core.TestEntry;
 import org.junit.Test;
@@ -18,13 +18,13 @@ public class SaveDeleteRefTest extends TransactionTest {
 
     @Test
     public void testSaveDeleteCommit() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(() -> {
+        Context tx = Context.instance();
+        tx.transaction(() -> {
             TestEntry entry = new TestEntry("CreateSaveDeleteCommitRef").save();
             ref = new RefTestEntry("CreateSaveDeleteCommitRef", entry).save();
         });
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             TestEntry actual = tx.get(TestEntry.class, "CreateSaveDeleteCommitRef");
             actual.delete();
         });
@@ -37,8 +37,8 @@ public class SaveDeleteRefTest extends TransactionTest {
 
     @Test
     public void testSaveDeleteRollback() {
-        Transaction tx = Transaction.instance();
-        tx.txCommit(() -> {
+        Context tx = Context.instance();
+        tx.transaction(() -> {
             TestEntry entry = new TestEntry("CreateSaveDeleteRollbackRef").save();
             ref = new RefTestEntry("CreateSaveDeleteRollbackRef", entry).save();
         });
@@ -47,7 +47,7 @@ public class SaveDeleteRefTest extends TransactionTest {
         actual.delete();
         tx.rollback();
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             TestEntry actualEntry = tx.get(TestEntry.class, "CreateSaveDeleteRollbackRef");
             assertNotNull(actualEntry);
             RefTestEntry actualRef = tx.get(RefTestEntry.class, ref.getKey());

--- a/src/test/java/org/boudnik/framework/test/testsuites/SaveGetComplexRefTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/SaveGetComplexRefTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.ComplexRefTestEntry;
 import org.boudnik.framework.test.core.RefTestEntry;
 import org.boudnik.framework.test.core.TestEntry;
@@ -18,11 +18,11 @@ public class SaveGetComplexRefTest extends TransactionTest {
 
     @Test
     public void testSaveGetCommit() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         TestEntry entry = new TestEntry("SaveGetCommitComplexRef");
         RefTestEntry ref = new RefTestEntry("SaveGetCommitComplexRef", entry);
         ComplexRefTestEntry complexRef = new ComplexRefTestEntry("SaveGetCommitComplexRef", ref);
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.save();
             ref.save();
             complexRef.save();
@@ -31,7 +31,7 @@ public class SaveGetComplexRefTest extends TransactionTest {
             assertSame(complexRef.getEntry(), ref);
         });
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             TestEntry actual = tx.get(TestEntry.class, "SaveGetCommitComplexRef");
             TestEntry expected = ref.getEntry();
             RefTestEntry actualRef = tx.get(RefTestEntry.class, ref.getKey());
@@ -44,7 +44,7 @@ public class SaveGetComplexRefTest extends TransactionTest {
 
     @Test
     public void testSaveGetRollback() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         TestEntry entry = new TestEntry("SaveGetRollbackComplexRef").save();
         RefTestEntry ref = new RefTestEntry("SaveGetRollbackComplexRef", entry).save();
         ComplexRefTestEntry complexRef = new ComplexRefTestEntry("SaveGetRollbackComplexRef", ref).save();

--- a/src/test/java/org/boudnik/framework/test/testsuites/SaveGetRefTest.java
+++ b/src/test/java/org/boudnik/framework/test/testsuites/SaveGetRefTest.java
@@ -1,7 +1,7 @@
 package org.boudnik.framework.test.testsuites;
 
 import org.boudnik.framework.CacheProvider;
-import org.boudnik.framework.Transaction;
+import org.boudnik.framework.Context;
 import org.boudnik.framework.test.core.RefTestEntry;
 import org.boudnik.framework.test.core.TestEntry;
 import org.junit.Test;
@@ -17,17 +17,17 @@ public class SaveGetRefTest extends TransactionTest {
 
     @Test
     public void testSaveGetCommit() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         TestEntry entry = new TestEntry("SaveGetCommitRef");
         RefTestEntry ref = new RefTestEntry("SaveGetCommitRef", entry);
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             entry.save();
             ref.save();
             assertSame(tx.get(TestEntry.class, "SaveGetCommitRef"), entry);
             assertSame(ref.getEntry(), entry);
         });
 
-        tx.txCommit(() -> {
+        tx.transaction(() -> {
             TestEntry actual = tx.get(TestEntry.class, "SaveGetCommitRef");
             TestEntry expected = ref.getEntry();
             assertSame(actual, expected);
@@ -38,7 +38,7 @@ public class SaveGetRefTest extends TransactionTest {
 
     @Test
     public void testSaveGetRollback() {
-        Transaction tx = Transaction.instance();
+        Context tx = Context.instance();
         TestEntry entry = new TestEntry("SaveGetRollbackRef").save();
         RefTestEntry ref = new RefTestEntry("SaveGetRollbackRef", entry).save();
 


### PR DESCRIPTION
Rename Transaction and txCommit() in more suitable way (Context and transaction())

https://github.com/aboudnik/kv-framework/issues/52